### PR TITLE
Conditionally use App Gateway V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,26 @@ Example module usage:
 
 ```hcl
 module "azurerm_front_door_waf" {
-  source  = "github.com/dfe-digital/terraform-azuerm-front-door-waf?ref=v0.2.0"
+  source  = "github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf?ref=v0.2.0"
 
+  ## General configuration
   environment    = "dev"
-  project_name   = "frontdoorwaf"
+  project_name   = "waf"
   azure_location = "uksouth"
+  existing_resource_group = "my-existing-rg"
+  # existing_virtual_network = ""
+  virtual_network_address_space = "172.16.0.0/12"
+  # enable_latency_monitor = false
+  # latency_monitor_threshold = 5000 # ms
+  # response_request_timeout = 60 # seconds
 
-  cdn_sku                     = "Premium_AzureFrontDoor" # or "Standard_AzureFrontDoor"
-  cdn_response_timeout        = 60 # seconds
+  ## Web Application Firewall configuration
+  enable_waf               = true
+  waf_mode                 = "Prevention" # or "Detection"
+  ## Choose whether to deploy an Azure Front Door, or an App Gateway
+  waf_application  = "CDN" # or "AppGatewayV2"
 
-  cdn_waf_targets = {
+  waf_targets = {
     "my-origin-name" = {
       domain = "my-fqdn.example.tld",
       # create_custom_domain = true,
@@ -49,55 +59,6 @@ module "azurerm_front_door_waf" {
     }
   }
 
-  ## Add custom HTTP Response Headers to all origins
-  # cdn_add_response_headers = [
-  #   {
-  #     name = "X-Apply-To-All-Origins",
-  #     value = "MyValue"
-  #   }
-  # ]
-
-  ## Remove HTTP Response Headers from all origins
-  # cdn_remove_response_headers = [
-  #   "X-Remove-Me"
-  # ]
-
-  enable_waf                            = true
-  waf_mode                              = "Prevention"
-  waf_enable_rate_limiting              = true
-  waf_rate_limiting_duration_in_minutes = 1
-  waf_rate_limiting_threshold           = 300
-  waf_rate_limiting_bypass_ip_list      = [
-    "8.8.8.8"
-  ]
-  waf_rate_limiting_action = "Block"
-  waf_managed_rulesets     = {
-    "BotProtection" = {
-      version = "preview-0.1",
-      action  = "Block"
-    },
-    "DefaultRuleSet" = {
-      version = "1.0",
-      action  = "Block",
-      overrides = {
-        "SQL" = {
-          "942110" = {
-            action = "Log"
-          },
-          "942150" = {
-            action = "Log",
-            exclusions = {
-              "my-test-exclusion" = {
-                match_variable = "RequestCookieNames",
-                operator = "StartsWith",
-                selector = "Foo"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
   waf_custom_rules = {
     "PostParamValuesfoo" = {
       priority = 10,
@@ -112,8 +73,112 @@ module "azurerm_front_door_waf" {
       }
     }
   }
-  waf_custom_block_response_status_code = 403
-  waf_custom_block_response_body = filebase64("my-error-page.html")
+
+  ## Azure Front Door specific configuration
+  cdn_sku = "Premium_AzureFrontDoor" # or "Standard_AzureFrontDoor"
+  # cdn_host_redirects = [
+  #   "my-site-redirect" = {
+  #     from = "example.com",
+  #     to = "my.example.com"
+  #   }
+  # ]
+  ## Add custom HTTP Response Headers to all origins
+  # cdn_add_response_headers = [
+  #   {
+  #     name = "X-Apply-To-All-Origins",
+  #     value = "MyValue"
+  #   }
+  # ]
+  ## Remove HTTP Response Headers from all origins
+  # cdn_remove_response_headers = [
+  #   "X-Remove-Me"
+  # ]
+  # cdn_waf_enable_rate_limiting              = false
+  # cdn_waf_rate_limiting_duration_in_minutes = 5
+  # cdn_waf_rate_limiting_threshold           = 1000
+  # cdn_waf_rate_limiting_bypass_ip_list      = [ 1.1.1.1, 8.8.8.8 ]
+  # cdn_waf_rate_limiting_action              = "Block" # one of "Allow", "Block", "Log"
+  cdn_waf_managed_rulesets = {
+    "BotProtection" = {
+      version = "preview-0.1",
+      action  = "Block"
+    },
+    "DefaultRuleSet" = {
+      version = "1.0",
+      action  = "Block"
+      # overrides = {
+      #   "SQLI" = {
+      #     "942440" = { # SQL Comment Sequence Detected
+      #       action = "Block"
+      #       exclusions = {
+      #         "rcn-sw-cookies" = {
+      #           match_variable = "RequestCookieNames"
+      #           operator       = "StartsWith"
+      #           selector       = ".MyCustom.Cookies" # .NET
+      #         },
+      #       }
+      #     }
+      #   }
+      # }
+    }
+  }
+  cdn_waf_custom_block_response_status_code = 503
+  cdn_waf_custom_block_response_body        = "<h1>Service unavailable</h1>"
+
+  ## Azure App Gateway specific configuration
+  # app_gateway_v2_capacity_units               = 1
+  # app_gateway_v2_frontend_port                = 443
+  # app_gateway_v2_cookie_based_affinity        = "Disabled" # or "Enabled"
+  # app_gateway_v2_tls_disabled_protocols       = ["TLSv1_0", "TLSv1_1"]
+  # app_gateway_v2_identity_ids                 = []
+  app_gateway_v2_waf_managed_rulesets           = {
+    "OWASP" = {
+      version = "3.2",
+      # overrides = {
+      #   "0000-RULE-GROUP-NAME-0000" = {
+      #     rules = {
+      #       "000001" = {
+      #         enabled = false
+      #       },
+      #       "000002" = {
+      #         enabled = true,
+      #         action  = "Log"
+      #       },
+      #     }
+      #   }
+      # }
+    },
+    "Microsoft_BotManagerRuleSet" = {
+      version = "1.0"
+    }
+  }
+  # app_gateway_v2_waf_managed_rulesets_exclusions = {
+  #   "rcn-sw-cookies" : {
+  #     match_variable = "RequestCookieNames",
+  #     selector = ".MyCustom.Cookies",
+  #     selector_match_operator = "StartsWith"
+  #     excluded_rule_set = {
+  #       "OWASP" = {
+  #         version         = "3.2",
+  #         rule_group_name = "0000-RULE-GROUP-NAME-0000",
+  #         excluded_rules  = [
+  #           "12345",
+  #           "67890"
+  #         ]
+  #       }
+  #       "Microsoft_BotManagerRuleSet" = {
+  #         version         = "1.0",
+  #         rule_group_name = "1111-RULE-GROUP-NAME-1111",
+  #         excluded_rules  = [
+  #           "12345",
+  #         ]
+  #       }
+  #     }
+  #   },
+  # }
+  ## If your App Gateway is expected to sit behind Azure Front Door, then set this to True to only permit inbound traffic from that source
+  # restrict_app_gateway_v2_to_front_door_inbound_only = true
+  # restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes = [ "*" ]
 
   tags = {
     "Environment"      = "Dev"
@@ -127,18 +192,21 @@ module "azurerm_front_door_waf" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.4 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.39.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 2.39.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [azurerm_application_gateway.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway) | resource |
 | [azurerm_cdn_frontdoor_custom_domain.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
 | [azurerm_cdn_frontdoor_endpoint.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
@@ -158,41 +226,71 @@ module "azurerm_front_door_waf" {
 | [azurerm_cdn_frontdoor_rule_set.origin_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_security_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
+| [azurerm_key_vault.app_gateway_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_log_analytics_workspace.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_diagnostic_setting.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_monitor_metric_alert.cdn_latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_network_security_group.app_gateway_v2_allow_frontdoor_inbound_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
+| [azurerm_subnet.app_gateway_v2_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet_network_security_group_association.app_gateway_v2_allow_frontdoor_inbound_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.app_gateway_v2_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_user_assigned_identity.app_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_web_application_firewall_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy) | resource |
+| [azuread_user.key_vault_app_gateway_certificates_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_user_assigned_identity.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_virtual_network.existing_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_app_gateway_v2_capacity_units"></a> [app\_gateway\_v2\_capacity\_units](#input\_app\_gateway\_v2\_capacity\_units) | App Gateway V2 capacity units | `number` | `1` | no |
+| <a name="input_app_gateway_v2_cookie_based_affinity"></a> [app\_gateway\_v2\_cookie\_based\_affinity](#input\_app\_gateway\_v2\_cookie\_based\_affinity) | App Gateway V2 Cookie Based Affinity. Sets an affinity cookie in the response with a hash value which contains the session details, so that the subsequent requests carrying the affinity cookie will be routed to the same backend server for maintaining stickiness. | `string` | `"Disabled"` | no |
+| <a name="input_app_gateway_v2_enable_http2"></a> [app\_gateway\_v2\_enable\_http2](#input\_app\_gateway\_v2\_enable\_http2) | App Gateway V2 enable HTTP2 | `bool` | `true` | no |
+| <a name="input_app_gateway_v2_frontend_port"></a> [app\_gateway\_v2\_frontend\_port](#input\_app\_gateway\_v2\_frontend\_port) | App Gateway V2 frontend port | `number` | `80` | no |
+| <a name="input_app_gateway_v2_identity_ids"></a> [app\_gateway\_v2\_identity\_ids](#input\_app\_gateway\_v2\_identity\_ids) | App Gateway V2 User Assigned identity ids. If empty, one will be created. | `list(any)` | `[]` | no |
+| <a name="input_app_gateway_v2_waf_managed_rulesets"></a> [app\_gateway\_v2\_waf\_managed\_rulesets](#input\_app\_gateway\_v2\_waf\_managed\_rulesets) | Map of all Managed rules you want to apply to the App Gateway WAF, including any overrides | <pre>map(object({<br>    version : string,<br>    overrides : optional(map(object({<br>      rules : map(object({<br>        enabled : bool,<br>        action : optional(string, "Block")<br>      }))<br>    })), {})<br>  }))</pre> | <pre>{<br>  "Microsoft_BotManagerRuleSet": {<br>    "version": "1.0"<br>  },<br>  "OWASP": {<br>    "version": "3.2"<br>  }<br>}</pre> | no |
+| <a name="input_app_gateway_v2_waf_managed_rulesets_exclusions"></a> [app\_gateway\_v2\_waf\_managed\_rulesets\_exclusions](#input\_app\_gateway\_v2\_waf\_managed\_rulesets\_exclusions) | Map of all exlusions and the assoicated Managed rules to apply to the App Gateway WAF | <pre>map(object({<br>    match_variable : string,<br>    selector : string,<br>    selector_match_operator : string,<br>    excluded_rule_set : map(object({<br>      version : string,<br>      rule_group_name : string,<br>      excluded_rules : list(string)<br>    }))<br>  }))</pre> | `{}` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_add_response_headers"></a> [cdn\_add\_response\_headers](#input\_cdn\_add\_response\_headers) | List of response headers to add at the CDN Front Door for all endpoints `[{ "Name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | `[]` | no |
 | <a name="input_cdn_host_redirects"></a> [cdn\_host\_redirects](#input\_cdn\_host\_redirects) | CDN FrontDoor host redirects `[{ "from" = "example.com", "to" = "www.example.com" }]` | `list(map(string))` | `[]` | no |
-| <a name="input_cdn_latency_monitor_threshold"></a> [cdn\_latency\_monitor\_threshold](#input\_cdn\_latency\_monitor\_threshold) | CDN latency monitor threshold in milliseconds | `number` | `5000` | no |
 | <a name="input_cdn_remove_response_headers"></a> [cdn\_remove\_response\_headers](#input\_cdn\_remove\_response\_headers) | List of response headers to remove at the CDN Front Door for all endpoints | `list(string)` | `[]` | no |
-| <a name="input_cdn_response_timeout"></a> [cdn\_response\_timeout](#input\_cdn\_response\_timeout) | Azure CDN Front Door response timeout in seconds | `number` | `120` | no |
 | <a name="input_cdn_sku"></a> [cdn\_sku](#input\_cdn\_sku) | Azure CDN Front Door SKU | `string` | `"Standard_AzureFrontDoor"` | no |
-| <a name="input_cdn_waf_targets"></a> [cdn\_waf\_targets](#input\_cdn\_waf\_targets) | Target endpoints to configure the WAF to point towards | <pre>map(<br>    object({<br>      domain : string,<br>      create_custom_domain : optional(bool, false),<br>      enable_health_probe : optional(bool, true),<br>      health_probe_interval : optional(number, 60),<br>      health_probe_request_type : optional(string, "HEAD"),<br>      health_probe_path : optional(string, "/"),<br>      cdn_add_response_headers : optional(list(object({<br>        name : string,<br>        value : string<br>        })<br>      ), [])<br>      cdn_add_request_headers : optional(list(object({<br>        name : string,<br>        value : string<br>        })<br>      ), [])<br>      cdn_remove_response_headers : optional(list(string), [])<br>      cdn_remove_request_headers : optional(list(string), [])<br>    })<br>  )</pre> | `{}` | no |
-| <a name="input_enable_cdn_latency_monitor"></a> [enable\_cdn\_latency\_monitor](#input\_enable\_cdn\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
-| <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable CDN Front Door WAF | `bool` | `false` | no |
+| <a name="input_cdn_waf_custom_block_response_body"></a> [cdn\_waf\_custom\_block\_response\_body](#input\_cdn\_waf\_custom\_block\_response\_body) | Base64 encoded custom response body when the WAF blocks a request | `string` | `""` | no |
+| <a name="input_cdn_waf_custom_block_response_status_code"></a> [cdn\_waf\_custom\_block\_response\_status\_code](#input\_cdn\_waf\_custom\_block\_response\_status\_code) | Custom response status code when the WAF blocks a request. | `number` | `0` | no |
+| <a name="input_cdn_waf_enable_rate_limiting"></a> [cdn\_waf\_enable\_rate\_limiting](#input\_cdn\_waf\_enable\_rate\_limiting) | Deploy a Rate Limiting Policy on the Front Door WAF | `bool` | `false` | no |
+| <a name="input_cdn_waf_managed_rulesets"></a> [cdn\_waf\_managed\_rulesets](#input\_cdn\_waf\_managed\_rulesets) | Map of all Managed rules you want to apply to the CDN WAF, including any overrides, or exclusions | <pre>map(object({<br>    version : string,<br>    action : optional(string, "Block"),<br>    exclusions : optional(map(object({<br>      match_variable : string,<br>      operator : string,<br>      selector : string<br>    })), {})<br>    overrides : optional(map(map(object({<br>      action : string,<br>      exclusions : optional(map(object({<br>        match_variable : string,<br>        operator : string,<br>        selector : string<br>      })), {})<br>    }))), {})<br>  }))</pre> | <pre>{<br>  "BotProtection": {<br>    "version": "preview-0.1"<br>  },<br>  "DefaultRuleSet": {<br>    "version": "1.0"<br>  }<br>}</pre> | no |
+| <a name="input_cdn_waf_rate_limiting_action"></a> [cdn\_waf\_rate\_limiting\_action](#input\_cdn\_waf\_rate\_limiting\_action) | Action to take when rate limiting (Block/Log) | `string` | `"Block"` | no |
+| <a name="input_cdn_waf_rate_limiting_bypass_ip_list"></a> [cdn\_waf\_rate\_limiting\_bypass\_ip\_list](#input\_cdn\_waf\_rate\_limiting\_bypass\_ip\_list) | List if IP CIDRs to bypass the Rate Limit Policy | `list(string)` | `[]` | no |
+| <a name="input_cdn_waf_rate_limiting_duration_in_minutes"></a> [cdn\_waf\_rate\_limiting\_duration\_in\_minutes](#input\_cdn\_waf\_rate\_limiting\_duration\_in\_minutes) | Number of minutes to BLOCK requests that hit the Rate Limit threshold | `number` | `1` | no |
+| <a name="input_cdn_waf_rate_limiting_threshold"></a> [cdn\_waf\_rate\_limiting\_threshold](#input\_cdn\_waf\_rate\_limiting\_threshold) | Maximum number of concurrent requests before Rate Limiting policy is applied | `number` | `300` | no |
+| <a name="input_enable_latency_monitor"></a> [enable\_latency\_monitor](#input\_enable\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
+| <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable WAF | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_monitor_action_group_id"></a> [existing\_monitor\_action\_group\_id](#input\_existing\_monitor\_action\_group\_id) | ID of an existing monitor action group | `string` | `""` | no |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Conditionally launch resources into an existing resource group. Specifying this will NOT create a resource group. | `string` | `""` | no |
+| <a name="input_existing_virtual_network"></a> [existing\_virtual\_network](#input\_existing\_virtual\_network) | Conditionally use an existing virtual network. The `virtual_network_address_space` must match an existing address space in the VNet. This also requires the resource group name. | `string` | `""` | no |
+| <a name="input_key_vault_app_gateway_certificates_access_ipv4"></a> [key\_vault\_app\_gateway\_certificates\_access\_ipv4](#input\_key\_vault\_app\_gateway\_certificates\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the App Gateway Certificates Key Vault | `list(string)` | `[]` | no |
+| <a name="input_key_vault_app_gateway_certificates_access_subnet_ids"></a> [key\_vault\_app\_gateway\_certificates\_access\_subnet\_ids](#input\_key\_vault\_app\_gateway\_certificates\_access\_subnet\_ids) | List of Azure Subnet IDs that are permitted to access the App Gateway Certificates Key Vault | `list(string)` | `[]` | no |
+| <a name="input_key_vault_app_gateway_certificates_access_users"></a> [key\_vault\_app\_gateway\_certificates\_access\_users](#input\_key\_vault\_app\_gateway\_certificates\_access\_users) | List of users that require access to the App Gateway Certificates Key Vault. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | `[]` | no |
+| <a name="input_latency_monitor_threshold"></a> [latency\_monitor\_threshold](#input\_latency\_monitor\_threshold) | CDN latency monitor threshold in milliseconds | `number` | `5000` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_response_request_timeout"></a> [response\_request\_timeout](#input\_response\_request\_timeout) | Azure CDN Front Door response timeout, or app gateway v2 request timeout in seconds | `number` | `120` | no |
+| <a name="input_restrict_app_gateway_v2_to_front_door_inbound_only"></a> [restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only](#input\_restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only) | Restricts access to the App Gateway V2 by creating a network security group that only allows 'AzureFrontDoor.Backend' inbound, and attaches it to the subnet of the application gateway. | `bool` | `false` | no |
+| <a name="input_restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes"></a> [restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only\_destination\_prefixes](#input\_restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only\_destination\_prefixes) | If app gateway v2 has access restricted to front door only (by enabling `restrict_app_gateway_v2_to_front_door_inbound_only`), use this to set the destination prefixes for the security group rule. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
-| <a name="input_waf_custom_block_response_body"></a> [waf\_custom\_block\_response\_body](#input\_waf\_custom\_block\_response\_body) | Base64 encoded custom response body when the WAF blocks a request | `string` | `""` | no |
-| <a name="input_waf_custom_block_response_status_code"></a> [waf\_custom\_block\_response\_status\_code](#input\_waf\_custom\_block\_response\_status\_code) | Custom response status code when the WAF blocks a request. | `number` | `0` | no |
+| <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
+| <a name="input_waf_application"></a> [waf\_application](#input\_waf\_application) | Which product to apply the WAF to. Must be either CDN or AppGatewayV2 | `string` | `"CDN"` | no |
 | <a name="input_waf_custom_rules"></a> [waf\_custom\_rules](#input\_waf\_custom\_rules) | Map of all Custom rules you want to apply to the WAF | <pre>map(object({<br>    priority : number,<br>    action : string,<br>    match_conditions : map(object({<br>      match_variable : string,<br>      match_values : list(string),<br>      operator : string,<br>      selector : optional(string, null)<br>    }))<br>  }))</pre> | `{}` | no |
-| <a name="input_waf_enable_rate_limiting"></a> [waf\_enable\_rate\_limiting](#input\_waf\_enable\_rate\_limiting) | Deploy a Rate Limiting Policy on the Front Door WAF | `bool` | `false` | no |
-| <a name="input_waf_managed_rulesets"></a> [waf\_managed\_rulesets](#input\_waf\_managed\_rulesets) | Map of all Managed rules you want to apply to the WAF, including any overrides | <pre>map(object({<br>    version : string,<br>    action : string,<br>    exclusions : optional(map(object({<br>      match_variable : string,<br>      operator : string,<br>      selector : string<br>    })), {})<br>    overrides : optional(map(map(object({<br>      action : string,<br>      exclusions : optional(map(object({<br>        match_variable : string,<br>        operator : string,<br>        selector : string<br>      })), {})<br>    }))), {})<br>  }))</pre> | `{}` | no |
-| <a name="input_waf_mode"></a> [waf\_mode](#input\_waf\_mode) | CDN Front Door WAF mode | `string` | `"Prevention"` | no |
-| <a name="input_waf_rate_limiting_action"></a> [waf\_rate\_limiting\_action](#input\_waf\_rate\_limiting\_action) | Action to take when rate limiting (Block/Log) | `string` | `"Block"` | no |
-| <a name="input_waf_rate_limiting_bypass_ip_list"></a> [waf\_rate\_limiting\_bypass\_ip\_list](#input\_waf\_rate\_limiting\_bypass\_ip\_list) | List if IP CIDRs to bypass the Rate Limit Policy | `list(string)` | `[]` | no |
-| <a name="input_waf_rate_limiting_duration_in_minutes"></a> [waf\_rate\_limiting\_duration\_in\_minutes](#input\_waf\_rate\_limiting\_duration\_in\_minutes) | Number of minutes to BLOCK requests that hit the Rate Limit threshold | `number` | `1` | no |
-| <a name="input_waf_rate_limiting_threshold"></a> [waf\_rate\_limiting\_threshold](#input\_waf\_rate\_limiting\_threshold) | Maximum number of concurrent requests before Rate Limiting policy is applied | `number` | `300` | no |
+| <a name="input_waf_mode"></a> [waf\_mode](#input\_waf\_mode) | WAF mode | `string` | `"Prevention"` | no |
+| <a name="input_waf_targets"></a> [waf\_targets](#input\_waf\_targets) | Target endpoints to configure the WAF to point towards | <pre>map(<br>    object({<br>      domain : string,<br>      cdn_create_custom_domain : optional(bool, false),<br>      custom_fqdn : optional(string, "")<br>      app_gateway_v2_ssl_certificate_key_vault_id : optional(string, "")<br>      enable_health_probe : optional(bool, true),<br>      health_probe_interval : optional(number, 60),<br>      health_probe_request_type : optional(string, "HEAD"),<br>      health_probe_path : optional(string, "/"),<br>      cdn_add_response_headers : optional(list(object({<br>        name : string,<br>        value : string<br>        })<br>      ), [])<br>      cdn_add_request_headers : optional(list(object({<br>        name : string,<br>        value : string<br>        })<br>      ), [])<br>      cdn_remove_response_headers : optional(list(string), [])<br>      cdn_remove_request_headers : optional(list(string), [])<br>    })<br>  )</pre> | `{}` | no |
 
 ## Outputs
 

--- a/app-gateway-v2.tf
+++ b/app-gateway-v2.tf
@@ -1,0 +1,145 @@
+resource "azurerm_user_assigned_identity" "app_gateway" {
+  count = local.app_gateway_v2_create_identity ? 1 : 0
+
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  name                = "${local.resource_prefix}-app-gateway"
+}
+
+resource "azurerm_key_vault" "app_gateway_certificates" {
+  name                       = "${local.resource_prefix}-agcerts"
+  location                   = local.resource_group.location
+  resource_group_name        = local.resource_group.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  enable_rbac_authorization  = false
+  purge_protection_enabled   = true
+
+  dynamic "access_policy" {
+    for_each = data.azuread_user.key_vault_app_gateway_certificates_access
+
+    content {
+      tenant_id = data.azurerm_client_config.current.tenant_id
+      object_id = access_policy.value["object_id"]
+
+      key_permissions = [
+        "Create",
+        "Get",
+      ]
+
+      secret_permissions = [
+        "Set",
+        "Get",
+        "Delete",
+        "Purge",
+        "Recover",
+        "List",
+      ]
+    }
+  }
+
+  dynamic "access_policy" {
+    for_each = local.app_gateway_v2_identity_principle_ids
+
+    content {
+      tenant_id = data.azurerm_client_config.current.tenant_id
+      object_id = access_policy.value
+
+      secret_permissions = [
+        "Get",
+        "List",
+      ]
+    }
+  }
+
+  network_acls {
+    bypass                     = "AzureServices"
+    default_action             = "Deny"
+    ip_rules                   = length(local.key_vault_app_gateway_certificates_access_ipv4) > 0 ? local.key_vault_app_gateway_certificates_access_ipv4 : null
+    virtual_network_subnet_ids = length(local.key_vault_app_gateway_certificates_access_subnet_ids) > 0 ? local.key_vault_app_gateway_certificates_access_subnet_ids : null
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_application_gateway" "waf" {
+  count = local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  name                = "${local.resource_prefix}-waf"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+
+  enable_http2 = local.app_gateway_v2_enable_http2
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = local.app_gateway_v2_capacity_units
+  }
+
+  gateway_ip_configuration {
+    name      = "default-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.app_gateway_v2_subnet[0].id
+  }
+
+  frontend_port {
+    name = "http"
+    port = local.app_gateway_v2_frontend_port
+  }
+
+  frontend_ip_configuration {
+    name                 = "default-frontend"
+    public_ip_address_id = azurerm_public_ip.app_gateway_v2[0].id
+  }
+
+  dynamic "backend_address_pool" {
+    for_each = local.waf_targets
+
+    content {
+      name  = backend_address_pool.key
+      fqdns = [backend_address_pool.value["domain"]]
+    }
+  }
+
+  backend_http_settings {
+    name                  = "backend-default"
+    cookie_based_affinity = local.app_gateway_v2_cookie_based_affinity
+    path                  = "/"
+    port                  = 443
+    protocol              = "Https"
+    request_timeout       = local.response_request_timeout
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = local.app_gateway_v2_identity_ids
+  }
+
+  dynamic "http_listener" {
+    for_each = local.waf_targets
+
+    content {
+      name                           = http_listener.key
+      host_names                     = [http_listener.value["domain"]]
+      frontend_ip_configuration_name = "default-frontend"
+      frontend_port_name             = "http"
+      protocol                       = "Http"
+    }
+  }
+
+  dynamic "request_routing_rule" {
+    for_each = local.waf_targets
+
+    content {
+      name                       = request_routing_rule.key
+      rule_type                  = "Basic"
+      http_listener_name         = request_routing_rule.key
+      backend_address_pool_name  = request_routing_rule.key
+      backend_http_settings_name = "backend-default"
+      priority                   = index(keys(local.waf_targets), request_routing_rule.key) + 1
+    }
+  }
+
+  firewall_policy_id = azurerm_web_application_firewall_policy.waf[0].id
+}

--- a/data.tf
+++ b/data.tf
@@ -3,3 +3,25 @@ data "azurerm_resource_group" "existing_resource_group" {
 
   name = local.existing_resource_group
 }
+
+data "azurerm_virtual_network" "existing_virtual_network" {
+  count = local.existing_virtual_network == "" ? 0 : 1
+
+  name                = local.existing_virtual_network
+  resource_group_name = local.existing_resource_group
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azuread_user" "key_vault_app_gateway_certificates_access" {
+  for_each = local.key_vault_app_gateway_certificates_access_users
+
+  user_principal_name = each.value
+}
+
+data "azurerm_user_assigned_identity" "app_gateway_v2" {
+  for_each = local.app_gateway_v2_identity_names
+
+  name                = each.value
+  resource_group_name = local.resource_group.name
+}

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -9,12 +9,12 @@ resource "azurerm_log_analytics_workspace" "waf" {
 
 resource "azurerm_monitor_diagnostic_setting" "waf" {
   name                           = "${local.resource_prefix}waf"
-  target_resource_id             = azurerm_cdn_frontdoor_profile.waf.id
+  target_resource_id             = local.waf_application == "CDN" ? azurerm_cdn_frontdoor_profile.waf[0].id : azurerm_application_gateway.waf[0].id
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.waf.id
   log_analytics_destination_type = "AzureDiagnostics"
 
   enabled_log {
-    category = "FrontdoorWebApplicationFirewallLog"
+    category = local.waf_application == "CDN" ? "FrontdoorWebApplicationFirewallLog" : "ApplicationGatewayFirewallLog"
 
     retention_policy {
       enabled = false

--- a/locals.tf
+++ b/locals.tf
@@ -1,36 +1,76 @@
 locals {
-  environment             = var.environment
-  project_name            = var.project_name
-  resource_prefix         = "${local.environment}${local.project_name}"
-  azure_location          = var.azure_location
-  existing_resource_group = var.existing_resource_group
-  resource_group          = local.existing_resource_group == "" ? azurerm_resource_group.default[0] : data.azurerm_resource_group.existing_resource_group[0]
+  environment              = var.environment
+  project_name             = var.project_name
+  resource_prefix          = "${local.environment}${local.project_name}"
+  azure_location           = var.azure_location
+  existing_resource_group  = var.existing_resource_group
+  resource_group           = local.existing_resource_group == "" ? azurerm_resource_group.default[0] : data.azurerm_resource_group.existing_resource_group[0]
+  existing_virtual_network = var.existing_virtual_network
+  create_virtual_network   = local.waf_application == "AppGatewayV2"
+  virtual_network_name = local.existing_virtual_network == "" ? (
+    local.create_virtual_network ? azurerm_virtual_network.default[0].name : ""
+  ) : data.azurerm_virtual_network.existing_virtual_network[0].name
+  virtual_network_address_space = var.virtual_network_address_space
+  virtual_network_address_space_mask = element(split("/", local.virtual_network_address_space
+  ), 1)
+  app_gateway_v2_subnet_cidr = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 0)
 
-  cdn_sku         = var.cdn_sku
-  cdn_waf_targets = var.cdn_waf_targets
+  app_gateway_v2_enable_http2 = var.app_gateway_v2_enable_http2
+
+  app_gateway_v2_capacity_units                                           = var.app_gateway_v2_capacity_units
+  app_gateway_v2_frontend_port                                            = var.app_gateway_v2_frontend_port
+  app_gateway_v2_cookie_based_affinity                                    = var.app_gateway_v2_cookie_based_affinity
+  restrict_app_gateway_v2_to_front_door_inbound_only                      = var.restrict_app_gateway_v2_to_front_door_inbound_only
+  restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes = var.restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes
+  app_gateway_v2_create_identity                                          = length(var.app_gateway_v2_identity_ids) == 0
+  app_gateway_v2_identity_ids                                             = local.app_gateway_v2_create_identity ? [azurerm_user_assigned_identity.app_gateway[0].id] : var.app_gateway_v2_identity_ids
+  app_gateway_v2_identity_names = toset([
+    for name in var.app_gateway_v2_identity_ids : basename(name)
+  ])
+  app_gateway_v2_identity_principle_ids = concat(
+    [
+      for identity in data.azurerm_user_assigned_identity.app_gateway_v2 :
+      identity.principal_id
+    ],
+    [
+      for identity in azurerm_user_assigned_identity.app_gateway :
+      identity.principal_id
+    ]
+  )
+  key_vault_app_gateway_certificates_access_users      = toset(var.key_vault_app_gateway_certificates_access_users)
+  key_vault_app_gateway_certificates_access_ipv4       = var.key_vault_app_gateway_certificates_access_ipv4
+  key_vault_app_gateway_certificates_access_subnet_ids = var.key_vault_app_gateway_certificates_access_subnet_ids
+
+  cdn_sku     = var.cdn_sku
+  waf_targets = var.waf_targets
   cdn_custom_domains = {
-    for cdn_waf_target_name, cdn_waf_target_value in local.cdn_waf_targets : cdn_waf_target_name => cdn_waf_target_value.fqdn if cdn_waf_target_value.create_custom_domain
+    for waf_target_name, waf_target_value in local.waf_targets : waf_target_name => waf_target_value.custom_fqdn if waf_target_value.cdn_create_custom_domain
   }
-  cdn_response_timeout        = var.cdn_response_timeout
+  response_request_timeout    = var.response_request_timeout
   cdn_host_redirects          = var.cdn_host_redirects
   cdn_add_response_headers    = var.cdn_add_response_headers
   cdn_remove_response_headers = var.cdn_remove_response_headers
 
   existing_monitor_action_group_id = var.existing_monitor_action_group_id
-  enable_cdn_latency_monitor       = var.enable_cdn_latency_monitor
-  cdn_latency_monitor_threshold    = var.cdn_latency_monitor_threshold
+  enable_latency_monitor           = var.enable_latency_monitor
+  latency_monitor_threshold        = var.latency_monitor_threshold
 
-  enable_waf                            = var.enable_waf
-  waf_managed_rulesets                  = var.waf_managed_rulesets
-  waf_custom_rules                      = var.waf_custom_rules
-  waf_mode                              = var.waf_mode
-  waf_custom_block_response_status_code = var.waf_custom_block_response_status_code
-  waf_custom_block_response_body        = var.waf_custom_block_response_body
-  waf_enable_rate_limiting              = var.waf_enable_rate_limiting
-  waf_rate_limiting_duration_in_minutes = var.waf_rate_limiting_duration_in_minutes
-  waf_rate_limiting_threshold           = var.waf_rate_limiting_threshold
-  waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
-  waf_rate_limiting_action              = var.waf_rate_limiting_action
+  enable_waf                                = var.enable_waf
+  waf_application                           = var.waf_application
+  waf_custom_rules                          = var.waf_custom_rules
+  waf_mode                                  = var.waf_mode
+  cdn_waf_custom_block_response_status_code = var.cdn_waf_custom_block_response_status_code
+  cdn_waf_custom_block_response_body        = var.cdn_waf_custom_block_response_body
+  cdn_waf_managed_rulesets                  = var.cdn_waf_managed_rulesets
+
+  app_gateway_v2_waf_managed_rulesets            = var.app_gateway_v2_waf_managed_rulesets
+  app_gateway_v2_waf_managed_rulesets_exclusions = var.app_gateway_v2_waf_managed_rulesets_exclusions
+
+  cdn_waf_enable_rate_limiting              = var.cdn_waf_enable_rate_limiting
+  cdn_waf_rate_limiting_duration_in_minutes = var.cdn_waf_rate_limiting_duration_in_minutes
+  cdn_waf_rate_limiting_threshold           = var.cdn_waf_rate_limiting_threshold
+  cdn_waf_rate_limiting_bypass_ip_list      = var.cdn_waf_rate_limiting_bypass_ip_list
+  cdn_waf_rate_limiting_action              = var.cdn_waf_rate_limiting_action
 
   tags = var.tags
 }

--- a/monitor.tf
+++ b/monitor.tf
@@ -1,10 +1,10 @@
-resource "azurerm_monitor_metric_alert" "cdn_latency" {
-  count = local.enable_cdn_latency_monitor && local.existing_monitor_action_group_id != "" ? 1 : 0
+resource "azurerm_monitor_metric_alert" "cdn" {
+  count = local.waf_application == "CDN" && local.enable_latency_monitor && local.existing_monitor_action_group_id != "" ? 1 : 0
 
-  name                = "${azurerm_cdn_frontdoor_profile.waf.name}-latency"
+  name                = "${azurerm_cdn_frontdoor_profile.waf[0].name}-latency"
   resource_group_name = local.resource_group.name
-  scopes              = [azurerm_cdn_frontdoor_profile.waf.id]
-  description         = "Action will be triggered when Origin latency is higher than ${local.cdn_latency_monitor_threshold}ms"
+  scopes              = [azurerm_cdn_frontdoor_profile.waf[0].id]
+  description         = "Action will be triggered when Origin latency is higher than ${local.latency_monitor_threshold}ms"
   window_size         = "PT5M"
   frequency           = "PT5M"
   severity            = 2
@@ -12,9 +12,35 @@ resource "azurerm_monitor_metric_alert" "cdn_latency" {
   criteria {
     metric_namespace = "Microsoft.Cdn/profiles"
     metric_name      = "TotalLatency"
-    aggregation      = "Average"
+    aggregation      = "Minimum"
     operator         = "GreaterThan"
-    threshold        = local.cdn_latency_monitor_threshold
+    threshold        = local.latency_monitor_threshold
+  }
+
+  action {
+    action_group_id = local.existing_monitor_action_group_id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "app_gateway_v2" {
+  count = local.waf_application == "AppGatewayV2" && local.enable_latency_monitor && local.existing_monitor_action_group_id != "" ? 1 : 0
+
+  name                = "${azurerm_application_gateway.waf[0].name}-latency"
+  resource_group_name = local.resource_group.name
+  scopes              = [azurerm_application_gateway.waf[0].id]
+  description         = "Action will be triggered when backend connection time is higher than ${local.latency_monitor_threshold}ms"
+  window_size         = "PT5M"
+  frequency           = "PT5M"
+  severity            = 2
+
+  criteria {
+    metric_namespace = "Microsoft.Network/applicationgateways"
+    metric_name      = "BackendConnectTime"
+    aggregation      = "Minimum"
+    operator         = "GreaterThan"
+    threshold        = local.latency_monitor_threshold
   }
 
   action {

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.51.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.39.0"
+    }
   }
 }

--- a/virtual-network.tf
+++ b/virtual-network.tf
@@ -1,0 +1,74 @@
+resource "azurerm_virtual_network" "default" {
+  count = local.create_virtual_network ? 1 : 0
+
+  name                = "${local.resource_prefix}default"
+  address_space       = [local.virtual_network_address_space]
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+  tags                = local.tags
+}
+
+resource "azurerm_route_table" "default" {
+  count = local.create_virtual_network ? 1 : 0
+
+  name                          = "${local.resource_prefix}default"
+  location                      = local.resource_group.location
+  resource_group_name           = local.resource_group.name
+  disable_bgp_route_propagation = false
+  tags                          = local.tags
+}
+
+resource "azurerm_subnet" "app_gateway_v2_subnet" {
+  count = local.create_virtual_network && local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  name                 = "${local.resource_prefix}app-gatway-v2"
+  virtual_network_name = local.virtual_network_name
+  resource_group_name  = local.resource_group.name
+  address_prefixes     = [local.app_gateway_v2_subnet_cidr]
+}
+
+resource "azurerm_subnet_route_table_association" "app_gateway_v2_subnet" {
+  count = local.create_virtual_network && local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  subnet_id      = azurerm_subnet.app_gateway_v2_subnet[0].id
+  route_table_id = azurerm_route_table.default[0].id
+}
+
+resource "azurerm_network_security_group" "app_gateway_v2_allow_frontdoor_inbound_only" {
+  count = local.create_virtual_network && local.waf_application == "AppGatewayV2" && local.restrict_app_gateway_v2_to_front_door_inbound_only ? 1 : 0
+
+  name                = "${local.resource_prefix}appgatewayv2sg"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+
+  security_rule {
+    name                         = "AllowFrontdoor"
+    priority                     = 100
+    direction                    = "Inbound"
+    access                       = "Allow"
+    protocol                     = "*"
+    source_port_range            = "*"
+    destination_port_range       = "443"
+    source_address_prefix        = "AzureFrontDoor.Backend"
+    destination_address_prefixes = local.restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "app_gateway_v2_allow_frontdoor_inbound_only" {
+  count = local.create_virtual_network && local.waf_application == "AppGatewayV2" && local.restrict_app_gateway_v2_to_front_door_inbound_only ? 1 : 0
+
+  subnet_id                 = azurerm_subnet.app_gateway_v2_subnet[0].id
+  network_security_group_id = azurerm_network_security_group.app_gateway_v2_allow_frontdoor_inbound_only[0].id
+}
+
+resource "azurerm_public_ip" "app_gateway_v2" {
+  count = local.create_virtual_network && local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  name                = "${local.resource_prefix}appgatewayv2"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}

--- a/waf.tf
+++ b/waf.tf
@@ -1,32 +1,34 @@
 resource "azurerm_cdn_frontdoor_firewall_policy" "waf" {
+  count = local.waf_application == "CDN" ? 1 : 0
+
   name                              = "${replace(local.resource_prefix, "-", "")}waf"
   resource_group_name               = local.resource_group.name
-  sku_name                          = azurerm_cdn_frontdoor_profile.waf.sku_name
+  sku_name                          = azurerm_cdn_frontdoor_profile.waf[0].sku_name
   enabled                           = local.enable_waf
   mode                              = local.waf_mode
-  custom_block_response_status_code = local.waf_custom_block_response_status_code != 0 ? local.waf_custom_block_response_status_code : null
-  custom_block_response_body        = local.waf_custom_block_response_body != "" ? local.waf_custom_block_response_body : null
+  custom_block_response_status_code = local.cdn_waf_custom_block_response_status_code != 0 ? local.cdn_waf_custom_block_response_status_code : null
+  custom_block_response_body        = local.cdn_waf_custom_block_response_body != "" ? local.cdn_waf_custom_block_response_body : null
 
   dynamic "custom_rule" {
-    for_each = local.waf_enable_rate_limiting ? [1] : []
+    for_each = local.cdn_waf_enable_rate_limiting ? [1] : []
 
     content {
       name                           = "RateLimiting"
       enabled                        = true
       priority                       = 1
-      rate_limit_duration_in_minutes = local.waf_rate_limiting_duration_in_minutes
-      rate_limit_threshold           = local.waf_rate_limiting_threshold
+      rate_limit_duration_in_minutes = local.cdn_waf_rate_limiting_duration_in_minutes
+      rate_limit_threshold           = local.cdn_waf_rate_limiting_threshold
       type                           = "RateLimitRule"
-      action                         = local.waf_rate_limiting_action
+      action                         = local.cdn_waf_rate_limiting_action
 
       dynamic "match_condition" {
-        for_each = length(local.waf_rate_limiting_bypass_ip_list) > 0 ? [1] : []
+        for_each = length(local.cdn_waf_rate_limiting_bypass_ip_list) > 0 ? [1] : []
 
         content {
           match_variable     = "RemoteAddr"
           operator           = "IPMatch"
           negation_condition = true
-          match_values       = local.waf_rate_limiting_bypass_ip_list
+          match_values       = local.cdn_waf_rate_limiting_bypass_ip_list
         }
       }
 
@@ -63,7 +65,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "waf" {
   }
 
   dynamic "managed_rule" {
-    for_each = local.waf_managed_rulesets
+    for_each = local.cdn_waf_managed_rulesets
 
     content {
       type    = managed_rule.key
@@ -109,22 +111,25 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "waf" {
       }
     }
   }
+
   tags = local.tags
 }
 
 resource "azurerm_cdn_frontdoor_security_policy" "waf" {
+  count = local.waf_application == "CDN" ? 1 : 0
+
   name                     = "${replace(local.resource_prefix, "-", "")}wafsecuritypolicy"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.waf.id
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.waf[0].id
 
   security_policies {
     firewall {
-      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.waf.id
+      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.waf[0].id
 
       association {
         patterns_to_match = ["/*"]
 
         dynamic "domain" {
-          for_each = local.cdn_waf_targets
+          for_each = local.waf_targets
 
           content {
             cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.waf[domain.key].id
@@ -141,4 +146,96 @@ resource "azurerm_cdn_frontdoor_security_policy" "waf" {
       }
     }
   }
+}
+
+resource "azurerm_web_application_firewall_policy" "waf" {
+  count = local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  name                = "${replace(local.resource_prefix, "-", "")}waf"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+
+  policy_settings {
+    enabled = local.enable_waf
+    mode    = local.waf_mode
+  }
+
+  dynamic "custom_rules" {
+    for_each = local.waf_custom_rules
+
+    content {
+      name      = custom_rules.key
+      priority  = custom_rules.value["priority"]
+      rule_type = "MatchRule"
+      action    = custom_rules.value["action"]
+
+      dynamic "match_conditions" {
+        for_each = custom_rules.value["match_conditions"]
+
+        content {
+          match_variables {
+            variable_name = match_conditions.value["match_variable"]
+            selector      = match_conditions.value["selector"]
+          }
+          match_values = match_conditions.value["match_values"]
+          operator     = match_conditions.value["operator"]
+        }
+      }
+    }
+  }
+
+  managed_rules {
+    dynamic "exclusion" {
+      for_each = local.app_gateway_v2_waf_managed_rulesets_exclusions
+
+      content {
+        match_variable          = exclusion.value.match_variable
+        selector                = exclusion.value.selector
+        selector_match_operator = exclusion.value.selector_match_operator
+
+        dynamic "excluded_rule_set" {
+          for_each = exclusion.value.excluded_rule_set
+
+          content {
+            type    = excluded_rule_set.key
+            version = excluded_rule_set.value.version
+
+            rule_group {
+              rule_group_name = excluded_rule_set.value.rule_group_name
+              excluded_rules  = excluded_rule_set.value.excluded_rules
+            }
+          }
+        }
+      }
+    }
+
+    dynamic "managed_rule_set" {
+      for_each = local.app_gateway_v2_waf_managed_rulesets
+
+      content {
+        type    = managed_rule_set.key
+        version = managed_rule_set.value.version
+
+        dynamic "rule_group_override" {
+          for_each = managed_rule_set.value.overrides
+
+          content {
+            rule_group_name = rule_group_override.key
+
+            dynamic "rule" {
+              for_each = rule_group_override.value.rules
+
+              content {
+                id      = rule.key
+                enabled = rule.value.enabled
+                action  = rule.value.action
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  tags = local.tags
 }


### PR DESCRIPTION
* We currently launch the WAF using Front Door. This change allows us to launch it using Application Gateway V2 instead.
* Using Application Gateway allows for more configuration options (eg hedaer modifications) and is preferable if using behind an existing Front Door CDN