### PR TITLE
fix: Prevent unnecessary resources being created for CDN

### DIFF
--- a/app-gateway-v2.tf
+++ b/app-gateway-v2.tf
@@ -7,6 +7,8 @@ resource "azurerm_user_assigned_identity" "app_gateway" {
 }
 
 resource "azurerm_key_vault" "app_gateway_certificates" {
+  count = local.waf_application == "AppGatewayV2" ? 1 : 0
+  
   name                       = "${local.resource_prefix}-agcerts"
   location                   = local.resource_group.location
   resource_group_name        = local.resource_group.name

--- a/app-gateway-v2.tf
+++ b/app-gateway-v2.tf
@@ -8,7 +8,7 @@ resource "azurerm_user_assigned_identity" "app_gateway" {
 
 resource "azurerm_key_vault" "app_gateway_certificates" {
   count = local.waf_application == "AppGatewayV2" ? 1 : 0
-  
+
   name                       = "${local.resource_prefix}-agcerts"
   location                   = local.resource_group.location
   resource_group_name        = local.resource_group.name

--- a/locals.tf
+++ b/locals.tf
@@ -22,7 +22,7 @@ locals {
   app_gateway_v2_cookie_based_affinity                                    = var.app_gateway_v2_cookie_based_affinity
   restrict_app_gateway_v2_to_front_door_inbound_only                      = var.restrict_app_gateway_v2_to_front_door_inbound_only
   restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes = var.restrict_app_gateway_v2_to_front_door_inbound_only_destination_prefixes
-  app_gateway_v2_create_identity                                          = length(var.app_gateway_v2_identity_ids) == 0
+  app_gateway_v2_create_identity                                          = local.waf_application == "AppGatewayV2" && length(var.app_gateway_v2_identity_ids) == 0
   app_gateway_v2_identity_ids                                             = local.app_gateway_v2_create_identity ? [azurerm_user_assigned_identity.app_gateway[0].id] : var.app_gateway_v2_identity_ids
   app_gateway_v2_identity_names = toset([
     for name in var.app_gateway_v2_identity_ids : basename(name)


### PR DESCRIPTION
Two App Gateway specific resources are created even if `waf_application` is set to `CDN`. Specifically:

- azurerm_user_assigned_identity.app_gateway
- azurerm_key_vault.app_gateway_certificates

This change:
- Ensures `waf_application` is `AppGatewayV2` when setting `app_gateway_v2_create_identity`.
- Ensures `waf_application` is `AppGatewayV2` when creating `azurerm_key_vault.app_gateway_certificates`