### PR TITLE
Remove deprecated property

### DIFF
--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -15,17 +15,9 @@ resource "azurerm_monitor_diagnostic_setting" "waf" {
 
   enabled_log {
     category = local.waf_application == "CDN" ? "FrontdoorWebApplicationFirewallLog" : "ApplicationGatewayFirewallLog"
-
-    retention_policy {
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-    }
   }
 }


### PR DESCRIPTION
Retention policies are defined in a different resource now so we don't need these