### PR TITLE
Deploy monitoring of WAF logs

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "1.9.0"
+  constraints = ">= 1.9.0"
+  hashes = [
+    "h1:shpEoqcAbf+p6AvspiYO1YrX//8l1LV/owEcQpujWHw=",
+    "zh:349569471fbf387feaaf8b88da1690669e201147c342f905e5eb03df42b3cf87",
+    "zh:54346d5fb78cbad3eb7cfd96e1dd7ce4f78666cabaaccfec6ee9437476330018",
+    "zh:64b799da915ea3a9a58ac7a926c6a31c59fd0d911687804d8e815eda88c5580b",
+    "zh:9336ed9e112555e0fda8af6be9ba21478e30117d79ba662233311d9560d2b7c6",
+    "zh:a8aace9897b28ea0b2dbd7a3be3df033e158af40412c9c7670be0956f216ed7e",
+    "zh:ab23df7de700d9e785009a4ca9ceb38ae1ab894a13f5788847f15d018556f415",
+    "zh:b4f13f0b13560a67d427c71c85246f8920f98987120341830071df4535842053",
+    "zh:e58377bf36d8a14d28178a002657865ee17446182dac03525fd43435e41a1b5c",
+    "zh:ea5db4acc6413fd0fe6b35981e58cdc9850f5f3118031cc3d2581de511aee6aa",
+    "zh:f0b32c06c6bd4e4af2c02a62be07b947766aeeb09289a03f21aba16c2fd3c60f",
+    "zh:f1518e766a90c257d7eb36d360dafaf311593a4a9352ff8db0bcfe0ed8cf45ae",
+    "zh:fa89e84cff0776b5b61ff27049b1d8ed52040bd58c81c4628890d644a6fb2989",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.40.0"
   constraints = ">= 2.39.0"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ module "azurerm_waf" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.1 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.9.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.39.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.51.0 |
 
@@ -200,6 +201,7 @@ module "azurerm_waf" {
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.9.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.40.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.66.0 |
 
@@ -229,9 +231,12 @@ module "azurerm_waf" {
 | [azurerm_cdn_frontdoor_security_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
 | [azurerm_key_vault.app_gateway_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_log_analytics_workspace.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_diagnostic_setting.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.appgateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.frontdoor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_network_security_group.app_gateway_v2_allow_frontdoor_inbound_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_public_ip.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
@@ -242,8 +247,10 @@ module "azurerm_waf" {
 | [azurerm_user_assigned_identity.app_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azurerm_web_application_firewall_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy) | resource |
+| [azapi_resource_action.existing_logic_app_workflow_callback_url](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource_action) | data source |
 | [azuread_user.key_vault_app_gateway_certificates_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_logic_app_workflow.existing_logic_app_workflow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/logic_app_workflow) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_user_assigned_identity.app_gateway_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_virtual_network.existing_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
@@ -275,6 +282,7 @@ module "azurerm_waf" {
 | <a name="input_enable_latency_monitor"></a> [enable\_latency\_monitor](#input\_enable\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
 | <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable WAF | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_existing_logic_app_workflow"></a> [existing\_logic\_app\_workflow](#input\_existing\_logic\_app\_workflow) | Name, Resource Group and HTTP Trigger URL of an existing Logic App Workflow | <pre>object({<br>    name : string<br>    resource_group_name : string<br>  })</pre> | <pre>{<br>  "name": "",<br>  "resource_group_name": ""<br>}</pre> | no |
 | <a name="input_existing_monitor_action_group_id"></a> [existing\_monitor\_action\_group\_id](#input\_existing\_monitor\_action\_group\_id) | ID of an existing monitor action group | `string` | `""` | no |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Conditionally launch resources into an existing resource group. Specifying this will NOT create a resource group. | `string` | `""` | no |
 | <a name="input_existing_virtual_network"></a> [existing\_virtual\_network](#input\_existing\_virtual\_network) | Conditionally use an existing virtual network. The `virtual_network_address_space` must match an existing address space in the VNet. This also requires the resource group name. | `string` | `""` | no |
@@ -282,6 +290,7 @@ module "azurerm_waf" {
 | <a name="input_key_vault_app_gateway_certificates_access_subnet_ids"></a> [key\_vault\_app\_gateway\_certificates\_access\_subnet\_ids](#input\_key\_vault\_app\_gateway\_certificates\_access\_subnet\_ids) | List of Azure Subnet IDs that are permitted to access the App Gateway Certificates Key Vault | `list(string)` | `[]` | no |
 | <a name="input_key_vault_app_gateway_certificates_access_users"></a> [key\_vault\_app\_gateway\_certificates\_access\_users](#input\_key\_vault\_app\_gateway\_certificates\_access\_users) | List of users that require access to the App Gateway Certificates Key Vault. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | `[]` | no |
 | <a name="input_latency_monitor_threshold"></a> [latency\_monitor\_threshold](#input\_latency\_monitor\_threshold) | CDN latency monitor threshold in milliseconds | `number` | `5000` | no |
+| <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | `[]` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_response_request_timeout"></a> [response\_request\_timeout](#input\_response\_request\_timeout) | Azure CDN Front Door response timeout, or app gateway v2 request timeout in seconds | `number` | `120` | no |
 | <a name="input_restrict_app_gateway_v2_to_front_door_inbound_only"></a> [restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only](#input\_restrict\_app\_gateway\_v2\_to\_front\_door\_inbound\_only) | Restricts access to the App Gateway V2 by creating a network security group that only allows 'AzureFrontDoor.Backend' inbound, and attaches it to the subnet of the application gateway. | `bool` | `false` | no |

--- a/data.tf
+++ b/data.tf
@@ -25,3 +25,27 @@ data "azurerm_user_assigned_identity" "app_gateway_v2" {
   name                = each.value
   resource_group_name = local.resource_group.name
 }
+
+data "azurerm_logic_app_workflow" "existing_logic_app_workflow" {
+  count = local.existing_logic_app_workflow.name == "" ? 0 : 1
+
+  name                = local.existing_logic_app_workflow.name
+  resource_group_name = local.existing_logic_app_workflow.resource_group_name
+}
+
+# There is not currently a way to get the full HTTP Trigger callback URL from a Logic App
+# so we have to use AzAPI to query the Logic App Workflow for the value instead.
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/18866
+data "azapi_resource_action" "existing_logic_app_workflow_callback_url" {
+  count = local.existing_logic_app_workflow.name == "" ? 0 : 1
+
+  resource_id = "${data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].id}/triggers/${data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].name}-trigger"
+  action      = "listCallbackUrl"
+  type        = "Microsoft.Logic/workflows/triggers@2018-07-01-preview"
+
+  depends_on = [
+    data.azurerm_logic_app_workflow.existing_logic_app_workflow[0]
+  ]
+
+  response_export_values = ["value"]
+}

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -17,7 +17,209 @@ resource "azurerm_monitor_diagnostic_setting" "waf" {
     category = local.waf_application == "CDN" ? "FrontdoorWebApplicationFirewallLog" : "ApplicationGatewayFirewallLog"
   }
 
+  enabled_log {
+    category = local.waf_application == "CDN" ? "FrontdoorAccessLog" : "ApplicationGatewayAccessLog"
+  }
+
   metric {
     category = "AllMetrics"
   }
+}
+
+resource "azurerm_monitor_action_group" "main" {
+  name                = "${local.resource_prefix}-actiongroup"
+  resource_group_name = local.resource_group.name
+  short_name          = local.project_name
+  tags                = local.tags
+
+  dynamic "email_receiver" {
+    for_each = local.monitor_email_receivers
+
+    content {
+      name                    = "Email ${email_receiver.value}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "logic_app_receiver" {
+    for_each = local.logic_app_workflow_name != "" ? [1] : []
+
+    content {
+      name                    = local.logic_app_workflow_name
+      resource_id             = local.logic_app_workflow_id
+      callback_url            = local.logic_app_workflow_callback_url
+      use_common_alert_schema = true
+    }
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "appgateway" {
+  count = local.waf_application == "AppGatewayV2" ? 1 : 0
+
+  name                 = "${local.resource_prefix}waflogs"
+  resource_group_name  = local.resource_group.name
+  location             = local.resource_group.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_log_analytics_workspace.waf.id]
+  severity             = 3
+  description          = "Incoming request was blocked by a WAF Rule"
+
+  criteria {
+    query = <<-QUERY
+      AzureDiagnostics
+        | where ResourceProvider == "MICROSOFT.NETWORK" and Category == "ApplicationGatewayFirewallLog"
+        | where TimeGenerated > ago(5min)
+        | where action_s == "Blocked"
+        | project hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | summarize ErrorCount=count() by hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | project ErrorCount, hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | order by ErrorCount desc
+      QUERY
+
+    time_aggregation_method = "Count"
+    threshold               = 5
+    operator                = "GreaterThanOrEqual"
+
+    dimension {
+      name     = "ErrorCount"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "hostname_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "ruleId_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "Message"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "requestUri_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "details_data_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "action_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled = true
+
+  action {
+    action_groups = [azurerm_monitor_action_group.main.id]
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
+  count = local.waf_application == "CDN" ? 1 : 0
+
+  name                 = "${local.resource_prefix}waflogs"
+  resource_group_name  = local.resource_group.name
+  location             = local.resource_group.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_log_analytics_workspace.waf.id]
+  severity             = 3
+  description          = "Incoming request was blocked by WAF Rule"
+
+  criteria {
+    query = <<-QUERY
+      AzureDiagnostics
+        | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontdoorWebApplicationFirewallLog"
+        | where TimeGenerated > ago(5min)
+        | where action_s == "Block"
+        | project hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | summarize ErrorCount=count() by hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | project ErrorCount, hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | order by ErrorCount desc
+      QUERY
+
+    time_aggregation_method = "Count"
+    threshold               = 5
+    operator                = "GreaterThanOrEqual"
+
+    dimension {
+      name     = "ErrorCount"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "hostname_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "ruleId_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "Message"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "requestUri_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "details_data_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "action_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled = true
+
+  action {
+    action_groups = [azurerm_monitor_action_group.main.id]
+  }
+
+  tags = local.tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -72,5 +72,11 @@ locals {
   cdn_waf_rate_limiting_bypass_ip_list      = var.cdn_waf_rate_limiting_bypass_ip_list
   cdn_waf_rate_limiting_action              = var.cdn_waf_rate_limiting_action
 
+  monitor_email_receivers         = var.monitor_email_receivers
+  existing_logic_app_workflow     = var.existing_logic_app_workflow
+  logic_app_workflow_name         = local.existing_logic_app_workflow.name == "" ? "" : data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].name
+  logic_app_workflow_id           = local.existing_logic_app_workflow.name == "" ? "" : data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].id
+  logic_app_workflow_callback_url = local.existing_logic_app_workflow.name == "" ? "" : jsondecode(data.azapi_resource_action.existing_logic_app_workflow_callback_url[0].output).value
+
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -322,3 +322,21 @@ variable "cdn_waf_custom_block_response_body" {
   type        = string
   default     = ""
 }
+
+variable "monitor_email_receivers" {
+  description = "A list of email addresses that should be notified by monitoring alerts"
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_logic_app_workflow" {
+  description = "Name, Resource Group and HTTP Trigger URL of an existing Logic App Workflow"
+  type = object({
+    name : string
+    resource_group_name : string
+  })
+  default = {
+    name                = ""
+    resource_group_name = ""
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/azuread"
       version = ">= 2.39.0"
     }
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.9.0"
+    }
   }
 }


### PR DESCRIPTION
- It is useful to be able to set up monitors for WAF Blocks so that we can investigate them when they happen
- Users can also supply a Logic App workflow to route alerts too (optional) which is useful if someone has a Slack integration!