### PR TITLE
Decrease the number of rows before alerting

### DIFF
--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -79,7 +79,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "appgateway" {
       QUERY
 
     time_aggregation_method = "Count"
-    threshold               = 5
+    threshold               = 1
     operator                = "GreaterThanOrEqual"
 
     dimension {
@@ -164,7 +164,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
       QUERY
 
     time_aggregation_method = "Count"
-    threshold               = 5
+    threshold               = 1
     operator                = "GreaterThanOrEqual"
 
     dimension {


### PR DESCRIPTION
- Having it set to 5 meant 5 different rules needed to be triggered before an alert was made. That was silly. It should alert on individual rules