### PR TITLE
fix: CDN WAF query

### DIFF
--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -154,12 +154,11 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
   criteria {
     query = <<-QUERY
       AzureDiagnostics
-        | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontdoorWebApplicationFirewallLog"
-        | where TimeGenerated > ago(5min)
+        | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontDoorWebApplicationFirewallLog"
         | where action_s == "Block"
-        | project hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
-        | summarize ErrorCount=count() by hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
-        | project ErrorCount, hostname_s, ruleId_s, Message, requestUri_s, details_data_s, action_s
+        | project host_s, ruleName_s, requestUri_s, details_data_s, action_s
+        | summarize ErrorCount=count() by host_s, ruleName_s, requestUri_s, details_data_s, action_s
+        | project ErrorCount, host_s, ruleName_s,requestUri_s, details_data_s, action_s
         | order by ErrorCount desc
       QUERY
 

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -155,6 +155,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
     query = <<-QUERY
       AzureDiagnostics
         | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontDoorWebApplicationFirewallLog"
+        | where TimeGenerated > ago(5min)
         | where action_s == "Block"
         | project host_s, ruleName_s, requestUri_s, details_data_s, action_s
         | summarize ErrorCount=count() by host_s, ruleName_s, requestUri_s, details_data_s, action_s

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -157,9 +157,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
         | where ResourceProvider == "MICROSOFT.CDN" and Category == "FrontDoorWebApplicationFirewallLog"
         | where TimeGenerated > ago(5min)
         | where action_s == "Block"
-        | project host_s, ruleName_s, requestUri_s, details_data_s, action_s
-        | summarize ErrorCount=count() by host_s, ruleName_s, requestUri_s, details_data_s, action_s
-        | project ErrorCount, host_s, ruleName_s,requestUri_s, details_data_s, action_s
+        | project host_s, ruleName_s, details_msg_s, requestUri_s, details_data_s, action_s
+        | summarize ErrorCount=count() by host_s, ruleName_s, details_msg_s, requestUri_s, details_data_s, action_s
+        | project ErrorCount, host_s, ruleName_s, requestUri_s, details_msg_s, details_data_s, action_s
         | order by ErrorCount desc
       QUERY
 
@@ -181,6 +181,12 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
 
     dimension {
       name     = "ruleName_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "details_msg_s"
       operator = "Include"
       values   = ["*"]
     }

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -174,19 +174,13 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
     }
 
     dimension {
-      name     = "hostname_s"
+      name     = "host_s"
       operator = "Include"
       values   = ["*"]
     }
 
     dimension {
-      name     = "ruleId_s"
-      operator = "Include"
-      values   = ["*"]
-    }
-
-    dimension {
-      name     = "Message"
+      name     = "ruleName_s"
       operator = "Include"
       values   = ["*"]
     }


### PR DESCRIPTION
Fixes issues with the query in `azurerm_monitor_scheduled_query_rules_alert_v2.frontdoor`.

1. Capitalisation in `FrontDoorWebApplicationFirewallLog`
2. Invalid column names
3. I removed the "Message" column. This likely would be `details_msg_s` but Azure was complaining about the complexity of the query

Since you're only doing a threshold of 1 for alerts, I wonder if this might be better as an `Any()` instead of a `Count()`, but I'm unsure of what the future development plans are with this (e.g. are you going to allow that to be an input? in which case obviously `any()` will not work).