### PR TITLE
feat: Add the ability to toggle on/off the WAF log alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ module "azurerm_waf" {
 | <a name="input_cdn_waf_rate_limiting_threshold"></a> [cdn\_waf\_rate\_limiting\_threshold](#input\_cdn\_waf\_rate\_limiting\_threshold) | Maximum number of concurrent requests before Rate Limiting policy is applied | `number` | `300` | no |
 | <a name="input_enable_latency_monitor"></a> [enable\_latency\_monitor](#input\_enable\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
 | <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable WAF | `bool` | `false` | no |
+| <a name="input_enable_waf_alert"></a> [enable\_waf\_alert](#input\_enable\_waf\_alert) | Toggle to enable or disable the WAF logs alert | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_logic_app_workflow"></a> [existing\_logic\_app\_workflow](#input\_existing\_logic\_app\_workflow) | Name, Resource Group and HTTP Trigger URL of an existing Logic App Workflow | <pre>object({<br>    name : string<br>    resource_group_name : string<br>  })</pre> | <pre>{<br>  "name": "",<br>  "resource_group_name": ""<br>}</pre> | no |
 | <a name="input_existing_monitor_action_group_id"></a> [existing\_monitor\_action\_group\_id](#input\_existing\_monitor\_action\_group\_id) | ID of an existing monitor action group | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -308,4 +308,4 @@ module "azurerm_waf" {
 | Name | Description |
 |------|-------------|
 | <a name="output_environment"></a> [environment](#output\_environment) | n/a |
-<!-- END_TF_DOCS -->
+<!-- END_TF_DOCS --> 

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -55,7 +55,7 @@ resource "azurerm_monitor_action_group" "main" {
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "appgateway" {
-  count = local.waf_application == "AppGatewayV2" ? 1 : 0
+  count = local.waf_application == "AppGatewayV2" && local.enable_waf_alert ? 1 : 0
 
   name                 = "${local.resource_prefix}waflogs"
   resource_group_name  = local.resource_group.name
@@ -140,7 +140,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "appgateway" {
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontdoor" {
-  count = local.waf_application == "CDN" ? 1 : 0
+  count = local.waf_application == "CDN" && local.enable_waf_alert ? 1 : 0
 
   name                 = "${local.resource_prefix}waflogs"
   resource_group_name  = local.resource_group.name

--- a/locals.tf
+++ b/locals.tf
@@ -57,6 +57,7 @@ locals {
 
   enable_waf                                = var.enable_waf
   waf_application                           = var.waf_application
+  enable_waf_alert                          = var.enable_waf_alert
   waf_custom_rules                          = var.waf_custom_rules
   waf_mode                                  = var.waf_mode
   cdn_waf_custom_block_response_status_code = var.cdn_waf_custom_block_response_status_code

--- a/variables.tf
+++ b/variables.tf
@@ -340,3 +340,9 @@ variable "existing_logic_app_workflow" {
     resource_group_name = ""
   }
 }
+
+variable "enable_waf_alert" {
+  description = "Toggle to enable or disable the WAF logs alert"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
**Problem**
On initial creation of the WAF the module fails to create the log rules in diagnostic.tf the reason for this is that at the time of creation there is no data in the AzureDiagnostic table so the module fails with an error similar to this `Failed to resolve column or scalar expression named 'action_s'`

**Proposed Solution**
The proposed work around for this is to give the user the ability to toggle off the creation of the alert if they are creating the WAF for the first time. 

To support this change, we have added a new input variable `enable_waf_alert` which defaults to `true`, if explicitly set to `false` the creation of the WAF log alert will be disabled.

