### PR TITLE
Shortened storage accounts to accommodate prefix

### DIFF
--- a/custom-error-storage.tf
+++ b/custom-error-storage.tf
@@ -1,7 +1,7 @@
 resource "azurerm_storage_account" "custom_error" {
   for_each = { for k, v in local.waf_targets : k => v if v["custom_errors"] != null }
 
-  name                          = "staticwebsite${substr(sha1(each.key), 0, 8)}"
+  name                          = "${replace(local.environment, "-", "")}staticwebsite${substr(sha1(each.key), 0, 4)}"
   resource_group_name           = local.resource_prefix
   location                      = local.azure_location
   account_tier                  = "Standard"


### PR DESCRIPTION
The static website storage accounts must all have globally unique names including across subscriptions so we can include the environment prefix in the name and shorten the hash suffix to 4 chars to stay within the name limit