### PR TITLE
Set SAS expiry to 2 days

### DIFF
--- a/custom-error-storage.tf
+++ b/custom-error-storage.tf
@@ -22,6 +22,10 @@ resource "azurerm_storage_account" "custom_error" {
     }
   }
 
+  sas_policy {
+    expiration_period = "02.00:00:00"
+  }
+
   tags = merge(local.tags, {
     "waf_target" = each.key
   })


### PR DESCRIPTION
Set the SAS token expiration date to 2 days (the default) 