### PR TITLE
Enable soft-delete retention for 7 days

### DIFF
--- a/custom-error-storage.tf
+++ b/custom-error-storage.tf
@@ -20,6 +20,14 @@ resource "azurerm_storage_account" "custom_error" {
       exposed_headers    = ["*"]
       max_age_in_seconds = 0
     }
+
+    delete_retention_policy {
+      days = 7
+    }
+
+    container_delete_retention_policy {
+      days = 7
+    }
   }
 
   sas_policy {


### PR DESCRIPTION
Storage Accounts should have soft-delete enabled even if we dont intend on using it