### PR TITLE
Set Access Key Expiration reminder for all storage accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ module "azurerm_waf" {
 
 | Name | Type |
 |------|------|
+| [azapi_update_resource.container_app_storage_key_rotation_reminder](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
 | [azurerm_application_gateway.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway) | resource |
 | [azurerm_cdn_frontdoor_custom_domain.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |

--- a/custom-error-storage.tf
+++ b/custom-error-storage.tf
@@ -31,6 +31,20 @@ resource "azurerm_storage_account" "custom_error" {
   })
 }
 
+resource "azapi_update_resource" "container_app_storage_key_rotation_reminder" {
+  for_each = { for k, v in local.waf_targets : k => v if v["custom_errors"] != null }
+
+  type        = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id = azurerm_storage_account.custom_error[each.key].id
+  body = jsonencode({
+    properties = {
+      keyPolicy : {
+        keyExpirationPeriodInDays : 90
+      }
+    }
+  })
+}
+
 resource "azurerm_storage_blob" "custom_error_web_pages" {
   for_each = merge([
     for k, v in local.waf_targets : {


### PR DESCRIPTION
All storage accounts should have the Access Key Expiry Reminder enabled and set to the recommended 90 days.