### PR TITLE
Specify Availability Zones for App Gateway deployment (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ module "azurerm_waf" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_app_gateway_v2_availability_zones"></a> [app\_gateway\_v2\_availability\_zones](#input\_app\_gateway\_v2\_availability\_zones) | List of Availability Zones in which the App Gateway should be located | `list(string)` | `[]` | no |
 | <a name="input_app_gateway_v2_capacity_units"></a> [app\_gateway\_v2\_capacity\_units](#input\_app\_gateway\_v2\_capacity\_units) | App Gateway V2 capacity units | `number` | `1` | no |
 | <a name="input_app_gateway_v2_cookie_based_affinity"></a> [app\_gateway\_v2\_cookie\_based\_affinity](#input\_app\_gateway\_v2\_cookie\_based\_affinity) | App Gateway V2 Cookie Based Affinity. Sets an affinity cookie in the response with a hash value which contains the session details, so that the subsequent requests carrying the affinity cookie will be routed to the same backend server for maintaining stickiness. | `string` | `"Disabled"` | no |
 | <a name="input_app_gateway_v2_custom_error_configuration"></a> [app\_gateway\_v2\_custom\_error\_configuration](#input\_app\_gateway\_v2\_custom\_error\_configuration) | A map of Status Codes to HTML URLs | `map(string)` | `{}` | no |

--- a/app-gateway-v2.tf
+++ b/app-gateway-v2.tf
@@ -81,8 +81,8 @@ resource "azurerm_application_gateway" "waf" {
   name                = "${local.resource_prefix}-waf"
   resource_group_name = local.resource_group.name
   location            = local.resource_group.location
-
-  enable_http2 = local.app_gateway_v2_enable_http2
+  zones               = local.app_gateway_v2_availability_zones
+  enable_http2        = local.app_gateway_v2_enable_http2
 
   sku {
     name     = "WAF_v2"

--- a/locals.tf
+++ b/locals.tf
@@ -16,10 +16,10 @@ locals {
   virtual_network_peering_targets = {
     for key, target in var.waf_targets : key => target.vnet_peering_target if target.vnet_peering_target != null && local.create_virtual_network
   }
-  app_gateway_v2_subnet_cidr  = cidrsubnet(local.virtual_network_address_space, 4, 0)
-  app_gateway_v2_private_ip   = cidrhost(local.virtual_network_address_space, 32 - local.virtual_network_address_space_mask)
-  app_gateway_v2_enable_http2 = var.app_gateway_v2_enable_http2
-
+  app_gateway_v2_subnet_cidr                                              = cidrsubnet(local.virtual_network_address_space, 4, 0)
+  app_gateway_v2_private_ip                                               = cidrhost(local.virtual_network_address_space, 32 - local.virtual_network_address_space_mask)
+  app_gateway_v2_enable_http2                                             = var.app_gateway_v2_enable_http2
+  app_gateway_v2_availability_zones                                       = var.app_gateway_v2_availability_zones
   app_gateway_v2_capacity_units                                           = var.app_gateway_v2_capacity_units
   app_gateway_v2_frontend_port                                            = var.app_gateway_v2_frontend_port
   app_gateway_v2_cookie_based_affinity                                    = var.app_gateway_v2_cookie_based_affinity

--- a/variables.tf
+++ b/variables.tf
@@ -351,6 +351,12 @@ variable "app_gateway_v2_waf_managed_rulesets_exclusions" {
   default = {}
 }
 
+variable "app_gateway_v2_availability_zones" {
+  description = "List of Availability Zones in which the App Gateway should be located"
+  type        = list(string)
+  default     = []
+}
+
 variable "waf_custom_rules" {
   description = "Map of all Custom rules you want to apply to the WAF"
   type = map(object({


### PR DESCRIPTION
Migrate Application Gateway and WAF deployments to availability zone support

>[!Warning]
>If you previously deployed Azure Application Gateway Standard v2 or Azure Application Gateway Standard v2 + WAF v2 without zonal support, you must redeploy these services to enable zone redundancy. Two migration options to redeploy these services are described in this [article](https://learn.microsoft.com/en-gb/azure/reliability/migrate-app-gateway-v2).