### PR TITLE
feat: add private link option to front door origin creation

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -39,6 +39,16 @@ resource "azurerm_cdn_frontdoor_origin" "waf" {
   origin_host_header             = each.value.domain
   http_port                      = 80
   https_port                     = 443
+
+  dynamic "private_link" {
+    for_each = lookup(each.value, "create_private", false) ? [1] : []
+
+    content {
+      private_link_target_id = each.value.private_link_target_id
+      location               = each.value.private_link_location
+      target_type            = lookup(each.value, "private_link_target_type", "managedEnvironments")
+    }
+  }
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "waf" {

--- a/variables.tf
+++ b/variables.tf
@@ -189,9 +189,30 @@ variable "waf_targets" {
         error_page_directory : string,
         error_pages : map(string)
       }), null)
+      # Private Link additions
+      create_private : optional(bool, false)
+      private_link_target_id : optional(string)
+      private_link_location  : optional(string)
+      private_link_target_type : optional(string, "managedEnvironments")
     })
   )
   default = {}
+
+  #private link validation
+  validation {
+    condition = alltrue([
+      for k, v in var.waf_targets :
+      (
+        !try(v.create_private, false) ||
+        (
+          try(v.private_link_target_id, null) != null &&
+          try(v.private_link_location, null) != null
+        )
+      )
+    ])
+
+    error_message = "When create_private is true, private_link_target_id and private_link_location must be provided."
+  }
 }
 
 variable "cdn_host_redirects" {


### PR DESCRIPTION
Addition of an option on each front door origin for it to be created as a private link
through defining new properties on it within the passed in waf_targets variable
private link will only be created if create_private is true

create_private = an optional bool defaulting to false

private_link_target_id : optional(string)
private_link_location  : optional(string)
private_link_target_type : optional(string, "managedEnvironments")

validation to ensure if create_private is true, the other properties have been provided